### PR TITLE
Small build reorg

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,0 +1,23 @@
+name: Build
+
+on:
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  java_build:
+    name: Build
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Set up JDK 11
+        uses: actions/setup-java@v1
+        with:
+          java-version: 11
+          server-id: github
+
+      - name: Build with Gradle
+        run: ./gradlew clean build

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -3,12 +3,6 @@ name: Publish
 on:
   release:
     types: [created]
-  push:
-    branches:
-    - main
-  pull_request:
-    branches:
-    - main
 
 jobs:
   java_build:

--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@
 [Provenance Blockchain Proto Docs](https://github.com/provenance-io/provenance/blob/main/docs/proto-docs.md) for
 client interface definitions.
 
+## Installation
 
 ### Maven
 
@@ -17,8 +18,20 @@ client interface definitions.
 
 ### Gradle
 
+#### Groovy
+
+In `build.gradle`:
+
 ```groovy
 implementation 'io.provenance.client:pb-grpc-client-kotlin:${version}'
+```
+
+#### Kotlin
+
+In `build.gradle.kts`:
+
+```kotlin
+implementation("io.provenance.client:pb-grpc-client-kotlin:${version}")
 ```
 
 ## Setup
@@ -54,10 +67,9 @@ Example: Querying the `marker` module for the access permissions on a marker:
 pbClient.markerClient.access(QueryAccessRequest.newBuilder().setId("marker address or denom here").build())
 ```
 
-
 ## Transaction Usage
 
-Example: creating a `Marker`
+### Example: creating a `Marker`
 
 ```kotlin
 val mnemonic = "your 20 word phrase here" // todo use your own mnemonic

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -23,7 +23,7 @@ plugins {
 repositories {
     mavenCentral()
     // For KEthereum library
-    maven(url="https://jitpack.io")
+    maven(url = "https://jitpack.io")
 }
 
 java {
@@ -48,9 +48,11 @@ object Versions {
 dependencies {
 
     // Kotlin
-    implementation("org.jetbrains.kotlin:kotlin-allopen:${Versions.Kotlin}")
-    implementation("org.jetbrains.kotlin:kotlin-reflect:${Versions.Kotlin}")
-    implementation("org.jetbrains.kotlin:kotlin-stdlib-jdk8:${Versions.Kotlin}")
+    // Pin kotlin packages together on a common version:
+    implementation(platform("org.jetbrains.kotlin:kotlin-bom:${Versions.Kotlin}"))
+    implementation("org.jetbrains.kotlin:kotlin-allopen")
+    implementation("org.jetbrains.kotlin:kotlin-reflect")
+    implementation("org.jetbrains.kotlin:kotlin-stdlib-jdk8")
 
     // Provenance
     implementation("io.provenance.protobuf:pb-proto-java:${Versions.ProvenanceProtos}")


### PR DESCRIPTION
- Pin kotlin dependencies together on a common version using kotlin-bom

- Add Gradle Kotlin DSL installation entry in README.md

- Split existing GitHub action workflow into two workflows:
  - For pull requests against main, build and run tests,
  - For releases, build, but skip tests, and publish jar to Maven
    Central