### PR TITLE
Add date and timestamp extension methods for protobuf builders

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -42,6 +42,7 @@ object Versions {
     val Kethereum = "0.83.4"
     val Komputing = "0.1"
     val Grpc = "1.42.0"
+    val Protobuf = "3.19.2"
     val Kotlin = "1.5.0"
 }
 
@@ -63,6 +64,9 @@ dependencies {
     implementation("io.grpc:grpc-netty:${Versions.Grpc}")
     implementation("io.grpc:grpc-protobuf:${Versions.Grpc}")
     implementation("io.grpc:grpc-stub:${Versions.Grpc}")
+
+    // Protobuf
+    implementation("com.google.protobuf:protobuf-java-util:${Versions.Protobuf}")
 
     // Crypto
     implementation("org.bouncycastle:bcprov-jdk15on:${Versions.BouncyCastle}")

--- a/src/main/kotlin/io/provenance/client/extensions/Protobuf.kt
+++ b/src/main/kotlin/io/provenance/client/extensions/Protobuf.kt
@@ -1,0 +1,115 @@
+package io.provenance.client.extensions
+
+import com.google.protobuf.Timestamp
+import com.google.protobuf.TimestampOrBuilder
+import com.google.protobuf.util.Timestamps
+import java.time.Instant
+import java.time.OffsetDateTime
+import java.time.ZoneId
+import java.time.ZonedDateTime
+
+// Extracted from https://github.com/FigureTechnologies/stream-data
+// https://github.com/FigureTechnologies/stream-data/blob/master/src/main/kotlin/com/figure/proto/extensions/Extensions.kt
+
+/**
+ * Store Instant as Timestamp (UTC)
+ */
+fun Timestamp.Builder.setValue(instant: Instant): Timestamp.Builder {
+    val max = Timestamps.MAX_VALUE
+    val min = Timestamps.MIN_VALUE
+    when {
+        instant.epochSecond > max.seconds -> this.seconds = max.seconds
+        instant.epochSecond < min.seconds -> this.seconds = min.seconds
+        else -> this.seconds = instant.epochSecond
+    }
+
+    when {
+        instant.nano > max.nanos -> this.nanos = max.nanos
+        instant.nano < min.nanos -> this.nanos = min.nanos
+        else -> this.nanos = instant.nano
+    }
+
+    return this
+}
+
+private fun TimestampOrBuilder.bound(): TimestampOrBuilder {
+    val max = Timestamps.MAX_VALUE
+    val min = Timestamps.MIN_VALUE
+    val new = Timestamp.newBuilder()
+    when {
+        this.seconds > max.seconds -> new.seconds = max.seconds
+        this.seconds < min.seconds -> new.seconds = min.seconds
+        else -> new.seconds = this.seconds
+    }
+
+    when {
+        this.nanos > max.nanos -> new.nanos = max.nanos
+        this.nanos < min.nanos -> new.nanos = min.nanos
+        else -> new.nanos = this.nanos
+    }
+
+    return new.build()
+}
+
+/**
+ * Get Timestamp as OffsetDateTime (system time zone) if can; otherwise, return null
+ */
+fun TimestampOrBuilder.toOffsetDateTimeOrNull(): OffsetDateTime? = try {
+    toOffsetDateTime(ZoneId.systemDefault())
+} catch (t: Throwable) {
+    null
+}
+
+/**
+ * Get Timestamp as OffsetDateTime (system time zone)
+ */
+fun TimestampOrBuilder.toOffsetDateTime(): OffsetDateTime = toOffsetDateTime(ZoneId.systemDefault())
+
+/**
+ * Get Timestamp as OffsetDateTime
+ */
+fun TimestampOrBuilder.toOffsetDateTimeOrNull(zoneId: ZoneId): OffsetDateTime? = try {
+    OffsetDateTime.ofInstant(bound().toInstant(), zoneId)
+} catch (t: Throwable) {
+    null
+}
+
+/**
+ * Get Timestamp as OffsetDateTime
+ */
+fun TimestampOrBuilder.toOffsetDateTime(zoneId: ZoneId) = OffsetDateTime.ofInstant(bound().toInstant(), zoneId)
+
+/**
+ * Get Timestamp as ZonedDateTime (system time zone)
+ */
+fun TimestampOrBuilder.toZonedDateTime(): ZonedDateTime = toZonedDateTime(ZoneId.systemDefault())
+
+/**
+ * Get Timestamp as ZonedDateTime
+ */
+fun TimestampOrBuilder.toZonedDateTime(zoneId: ZoneId): ZonedDateTime = ZonedDateTime.ofInstant(toInstant(), zoneId)
+
+/**
+ * Get Timestamp as Instant
+ */
+fun TimestampOrBuilder.toInstant(): Instant = Instant.ofEpochSecond(seconds, nanos.toLong())
+
+/**
+ * Quick convert OffsetDateTime to Timestamp
+ */
+fun OffsetDateTime.toProtoTimestamp(): Timestamp = Timestamp.newBuilder().setValue(this).build()
+
+/**
+ * Quick convert ZonedDateTime to Timestamp
+ */
+fun ZonedDateTime.toProtoTimestamp(): Timestamp = Timestamp.newBuilder().setValue(this).build()
+
+/**
+ * Store OffsetDateTime as Timestamp (UTC)
+ */
+fun Timestamp.Builder.setValue(odt: OffsetDateTime): Timestamp.Builder = setValue(odt.toInstant())
+
+/**
+ * Store ZonedDateTime as Timestamp (UTC)
+ */
+fun Timestamp.Builder.setValue(odt: ZonedDateTime): Timestamp.Builder = setValue(odt.toInstant())


### PR DESCRIPTION
This adds some protobuf builder methods which I've encountered and could be a useful addition into the library. I wanted to access them, but they're defined in https://github.com/FigureTechnologies/stream-data, but I didn't want to add that as a project dependency (here or elsewhere), since there's a lot of other stuff that's not needed.

@vwagner Let me know if this is a good place for it, or if you think https://github.com/provenance-io/provenance-protobuf-java is a better location.

