### PR TITLE
Add feeGranter property to BaseReq

### DIFF
--- a/src/main/kotlin/io/provenance/client/grpc/BaseReq.kt
+++ b/src/main/kotlin/io/provenance/client/grpc/BaseReq.kt
@@ -28,7 +28,8 @@ data class BaseReq(
     val signers: List<BaseReqSigner>,
     val body: TxBody,
     val chainId: String,
-    val gasAdjustment: Double? = null
+    val gasAdjustment: Double? = null,
+    val feeGranter: String? = null
 ) {
 
     fun buildAuthInfo(gasEstimate: GasEstimate = GasEstimate(0)): AuthInfo =
@@ -44,6 +45,11 @@ data class BaseReq(
                         )
                     )
                     .setGasLimit(gasEstimate.limit)
+                    .also {
+                        if (feeGranter != null) {
+                            it.granter = feeGranter
+                        }
+                    }
             )
             .addAllSignerInfos(
                 signers.map {

--- a/src/main/kotlin/io/provenance/client/grpc/PbClient.kt
+++ b/src/main/kotlin/io/provenance/client/grpc/PbClient.kt
@@ -16,7 +16,6 @@ import java.util.concurrent.ExecutorService
 import java.util.concurrent.Executors
 import java.util.concurrent.TimeUnit
 
-
 data class ChannelOpts(
     val inboundMessageSize: Int = 40 * 1024 * 1024, // ~ 20 MB
     val idleTimeout: Pair<Long, TimeUnit> = 5L to TimeUnit.MINUTES,
@@ -31,7 +30,6 @@ class PbClient(
     opts: ChannelOpts = ChannelOpts(),
     channelConfigLambda: (NettyChannelBuilder) -> Unit = { }
 ) : Closeable {
-
 
     val channel = NettyChannelBuilder.forAddress(channelUri.host, channelUri.port)
         .apply {
@@ -84,6 +82,7 @@ class PbClient(
         txBody: TxBody,
         signers: List<BaseReqSigner>,
         gasAdjustment: Double? = null,
+        feeGranter: String? = null,
     ): BaseReq =
         signers.map {
             BaseReqSigner(
@@ -96,7 +95,8 @@ class PbClient(
                 signers = it,
                 body = txBody,
                 chainId = chainId,
-                gasAdjustment = gasAdjustment
+                gasAdjustment = gasAdjustment,
+                feeGranter = feeGranter
             )
         }
 
@@ -151,10 +151,12 @@ class PbClient(
         signers: List<BaseReqSigner>,
         mode: ServiceOuterClass.BroadcastMode = ServiceOuterClass.BroadcastMode.BROADCAST_MODE_SYNC,
         gasAdjustment: Double? = null,
+        feeGranter: String? = null
     ): ServiceOuterClass.BroadcastTxResponse = baseRequest(
         txBody = txBody,
         signers = signers,
-        gasAdjustment = gasAdjustment
+        gasAdjustment = gasAdjustment,
+        feeGranter = feeGranter
     ).let { baseReq -> broadcastTx(baseReq, estimateTx(baseReq), mode) }
 
     fun getBaseAccount(bech32Address: String): Auth.BaseAccount =
@@ -166,6 +168,4 @@ class PbClient(
                 else -> throw IllegalArgumentException("Account type not handled:$typeUrl")
             }
         }
-
 }
-


### PR DESCRIPTION
Adds the missing optional`feeGranter` property in `BaseReq` like that in the service-wallet `GrpcClient` implementation in `pb-client` https://github.com/FigureTechnologies/service-wallet/blob/f413cb16e111095a98a6b26f5f43e1e69fc22deb/pb-client/src/main/kotlin/com/figure/wallet/pbclient/client/GrpcClient.kt#L42

@vwagner I don't know if this purposefully left out, or was added later to service-wallet but not yet reflected in this repo. 

It was originally added to wallet-service by @tbrooks-figure and relates to work @mplokita-figure is currently doing. 