### PR TITLE
Update dependencies and remove unused ones

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -37,12 +37,10 @@ val projectVersion = project.property("version")?.takeIf { it != "unspecified" }
 
 object Versions {
     val ProvenanceProtos = "1.7.0-0.0.2"
-    val ProvenanceHDWallet = "0.1.9"
-    val BouncyCastle = "1.63"
-    val Kethereum = "0.83.4"
-    val Komputing = "0.1"
-    val Grpc = "1.42.0"
-    val Kotlin = "1.5.0"
+    val ProvenanceHDWallet = "0.1.13"
+    val BouncyCastle = "1.70"
+    val Grpc = "1.42.2"
+    val Kotlin = "1.5.32"
 }
 
 dependencies {
@@ -66,15 +64,6 @@ dependencies {
 
     // Crypto
     implementation("org.bouncycastle:bcprov-jdk15on:${Versions.BouncyCastle}")
-    implementation("com.github.komputing.kethereum:bip32:${Versions.Kethereum}")
-    implementation("com.github.komputing.kethereum:bip39:${Versions.Kethereum}")
-    implementation("com.github.komputing.kethereum:crypto:${Versions.Kethereum}")
-    implementation("com.github.komputing.kethereum:crypto_api:${Versions.Kethereum}")
-    implementation("com.github.komputing.kethereum:crypto_impl_bouncycastle:${Versions.Kethereum}")
-    implementation("com.github.komputing.kethereum:extensions_kotlin:${Versions.Kethereum}")
-    implementation("com.github.komputing.kethereum:model:${Versions.Kethereum}")
-    implementation("com.github.komputing:kbase58:${Versions.Komputing}")
-    implementation("com.github.komputing:kbip44:${Versions.Komputing}")
 
     // Test
     testImplementation("org.jetbrains.kotlin:kotlin-test")

--- a/src/main/kotlin/io/provenance/client/wallet/WalletSigner.kt
+++ b/src/main/kotlin/io/provenance/client/wallet/WalletSigner.kt
@@ -29,10 +29,13 @@ class WalletSigner(networkType: NetworkType, mnemonic: String, passphrase: Strin
 
     val account: Account = wallet[networkType.path]
 
-    override fun address(): String = account.address
+    override fun address(): String = account.address.value
 
     override fun pubKey(): Keys.PubKey =
-        Keys.PubKey.newBuilder().setKey(ByteString.copyFrom(account.keyPair.publicKey.compressed())).build()
+        Keys.PubKey
+            .newBuilder()
+            .setKey(ByteString.copyFrom(account.keyPair.publicKey.compressed()))
+            .build()
 
     override fun sign(data: ByteArray): ByteArray = BCECSigner()
         .sign(account.keyPair.privateKey, data.sha256())


### PR DESCRIPTION
- Update BC to 1.70 which fixes listed vurnerabilities
  See https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2020-28052

- Remove unused kethereum dependencies. Capabilities handled by those
  libraries are included in provenance/hdwallet

- Update hdwallet to latest version

- Update grpc with latest 1.42.x patch release

- Update Kotlin to last 1.5.x release (1.5.32 before 1.6.0)