### PR TITLE
Upgrade hdwallet + update README with hdwallet example

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,3 +93,101 @@ pbClient.estimateAndBroadcastTx(
 **Note**: In general, `BROADCAST_MODE_BLOCK` is not recommended as your transaction may become successful past the time that 
 client blocks while waiting for the response. Instead use `BROADCAST_MODE_SYNC`, and listen for transaction success
 in the [Event Stream](https://github.com/provenance-io/event-stream) or query the client with the transaction hash to find the outcome of submission.
+
+### Example: using an existing wallet created with [hdwallet](https://github.com/provenance-io/hdwallet/)
+
+```kotlin
+import com.google.protobuf.Any
+import com.google.protobuf.ByteString
+import com.google.protobuf.GeneratedMessageV3
+import com.google.protobuf.Message
+import cosmos.bank.v1beta1.Tx
+import cosmos.base.v1beta1.CoinOuterClass
+import cosmos.crypto.secp256k1.Keys
+import cosmos.tx.v1beta1.TxOuterClass
+import io.provenance.client.grpc.BaseReqSigner
+import io.provenance.client.grpc.Signer
+import io.provenance.client.wallet.NetworkType
+import io.provenance.hdwallet.bip39.MnemonicWords
+import io.provenance.hdwallet.wallet.Account
+import io.provenance.hdwallet.wallet.Wallet
+import java.net.URI
+import java.util.concurrent.TimeUnit
+
+// Some helper extension methods:
+fun Message.toAny(typeUrlPrefix: String = ""): Any = Any.pack(this, typeUrlPrefix)
+
+fun Iterable<Any>.toTxBody(memo: String? = null): TxOuterClass.TxBody =
+    TxOuterClass.TxBody.newBuilder()
+        .addAllMessages(this)
+        .also { builder -> memo?.run { builder.memo = this } }
+        .build()
+
+fun main(args: Array<String>) {
+
+    // Create a wallet using the hdwallet library:
+    val wallet = Wallet.fromMnemonic(
+        hrp = NetworkType.TESTNET.prefix,
+        passphrase = "",
+        mnemonicWords = MnemonicWords.of("fly fly comfort"),
+        testnet = true
+    )
+
+    // Derive an account from a path:
+    val account: Account = wallet[NetworkType.TESTNET.path]
+    val address: String = account.address.value
+
+    // Construct the Provenance client:
+    val pbClient = PbClient(
+        chainId = "chain-local",
+        channelUri = URI("http://localhost:9090"),
+        opts = ChannelOpts(idleTimeout = (1L to TimeUnit.MINUTES))
+    )
+
+    // Implement the [Signer] interface for signing transactions on Provenance:
+    val signer = object : Signer {
+        override fun address(): String = address
+
+        override fun pubKey(): Keys.PubKey =
+            Keys.PubKey
+                .newBuilder()
+                .setKey(ByteString.copyFrom(account.keyPair.publicKey.compressed()))
+                .build()
+
+        override fun sign(data: ByteArray): ByteArray = account.sign(data)
+    }
+
+    // Send some hash from one account to another:
+    val senderAddress = address
+    val receiverAddress = "tp1pxxgsr8efdxvfylxg5uewpalds6cg6c8eg0l9m"
+
+    println("Sending hash from $senderAddress to $receiverAddress")
+
+    // 1. Construct the coin amount:
+    val amount: CoinOuterClass.Coin = CoinOuterClass.Coin
+        .newBuilder()
+        .setDenom("nhash")
+        .setAmount("1")
+        .build()
+
+    // 2. Build the send message:
+    val sendMessage: GeneratedMessageV3 =
+        Tx.MsgSend.newBuilder()
+            .setFromAddress(senderAddress)
+            .setToAddress(receiverAddress)
+            .addAmount(amount)
+            .build()
+
+    // 3. Wrap the message in a transaction body:
+    val txBody: TxOuterClass.TxBody = listOf(sendMessage.toAny()).toTxBody()
+
+    // 4. Estimate the gas fee for the transaction and broad cast it to the blockchain:
+    val response = pbClient.estimateAndBroadcastTx(
+        txBody = txBody,
+        signers = listOf(BaseReqSigner(signer))
+    )
+
+    println(if (response.txResponse.code == 0) "ok" else "error")
+    println(response)
+}
+```

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -28,7 +28,7 @@ repositories {
 
 java {
     sourceCompatibility = JavaVersion.VERSION_11
-    targetCompatibility = JavaVersion.VERSION_1_8
+    targetCompatibility = JavaVersion.VERSION_11
     withSourcesJar()
     withJavadocJar()
 }
@@ -37,7 +37,7 @@ val projectVersion = project.property("version")?.takeIf { it != "unspecified" }
 
 object Versions {
     val ProvenanceProtos = "1.7.0-0.0.2"
-    val ProvenanceHDWallet = "0.1.13"
+    val ProvenanceHDWallet = "0.1.15"
     val BouncyCastle = "1.70"
     val Grpc = "1.42.2"
     val Kotlin = "1.5.32"

--- a/src/main/kotlin/io/provenance/client/wallet/WalletSigner.kt
+++ b/src/main/kotlin/io/provenance/client/wallet/WalletSigner.kt
@@ -40,4 +40,5 @@ class WalletSigner(networkType: NetworkType, mnemonic: String, passphrase: Strin
     override fun sign(data: ByteArray): ByteArray = BCECSigner()
         .sign(account.keyPair.privateKey, data.sha256())
         .encodeAsBTC()
+        .toByteArray()
 }


### PR DESCRIPTION
- Update hdwallet dependency to 0.1.15

- Set target compatibility to Java 11

- Update READ with complete example of how to use pb-grpc-client-lib
  with an existing wallet created withhdwallet