### PR TITLE
Support BIP-32 keys

### DIFF
--- a/src/main/kotlin/io/provenance/client/wallet/NetworkType.kt
+++ b/src/main/kotlin/io/provenance/client/wallet/NetworkType.kt
@@ -1,0 +1,17 @@
+package io.provenance.client.wallet
+
+import io.provenance.hdwallet.hrp.Hrp
+
+enum class NetworkType(
+    /**
+     * The hrp (Human Readable Prefix) of the network address.
+     */
+    val prefix: String,
+    /**
+     * The HD wallet path.
+     */
+    val path: String,
+) {
+    TESTNET(prefix = Hrp.ProvenanceBlockchain.testnet, path = "m/44'/1'/0'/0/0'"),
+    MAINNET(prefix = Hrp.ProvenanceBlockchain.mainnet, path = "m/505'/1'/0'/0/0")
+}

--- a/src/main/kotlin/io/provenance/client/wallet/WalletSigner.kt
+++ b/src/main/kotlin/io/provenance/client/wallet/WalletSigner.kt
@@ -5,33 +5,85 @@ import cosmos.crypto.secp256k1.Keys
 import io.provenance.client.grpc.Signer
 import io.provenance.hdwallet.bip39.MnemonicWords
 import io.provenance.hdwallet.common.hashing.sha256
-import io.provenance.hdwallet.hrp.Hrp
 import io.provenance.hdwallet.signer.BCECSigner
 import io.provenance.hdwallet.wallet.Account
 import io.provenance.hdwallet.wallet.Wallet
 
-enum class NetworkType(
-    /**
-     * The hrp (Human Readable Prefix) of the network address
-     */
-    val prefix: String,
-    /**
-     * The HD wallet path
-     */
-    val path: String
-) {
-    TESTNET(prefix = Hrp.ProvenanceBlockchain.testnet, path = "m/44'/1'/0'/0/0'"),
-    MAINNET(prefix = Hrp.ProvenanceBlockchain.mainnet, path = "m/505'/1'/0'/0/0")
+/**
+ * Create a [WalletSigner] from a BIP-39 mnemonic.
+ *
+ * @param prefix The human-readable prefix to use when generating network addresses.
+ * @param path The key derivation path to use.
+ * @param mnemonic The mnemonic phrase list used to generate the key used by the wallet for signing.
+ * @param passphrase An optional passphrase to use when generating the key used by the wallet for signing. Default is `""`.
+ * @param isMainNet If true, mainnet keys will be generated, otherwise testnet keys will be generated. The default is false.
+ * @return [WalletSigner]
+ */
+fun fromMnemonic(
+    prefix: String,
+    path: String,
+    mnemonic: String,
+    passphrase: String = "",
+    isMainNet: Boolean = false,
+): WalletSigner {
+    val wallet: Wallet = Wallet.fromMnemonic(
+        hrp = prefix,
+        passphrase = passphrase,
+        mnemonicWords = MnemonicWords.of(mnemonic),
+        testnet = !isMainNet
+    )
+    return WalletSigner(wallet[path])
 }
 
-class WalletSigner(prefix: String, path: String, mnemonic: String, passphrase: String = "") : Signer {
+/**
+ * Create a [WalletSigner] from a BIP-39 mnemonic.
+ *
+ * @param networkType Use a defined [NetworkType] to specify the path and prefix when generating the signing key.
+ * @param mnemonic The mnemonic phrase list used to generate the key used by the wallet for signing.
+ * @param passphrase An optional passphrase to use when generating the key used by the wallet for signing. Default is `""`.
+ * @param isMainNet If true, mainnet keys will be generated, otherwise testnet keys will be generated. The default is false.
+ * @return [WalletSigner]
+ */
+fun fromMnemonic(
+    networkType: NetworkType,
+    mnemonic: String,
+    passphrase: String = "",
+    isMainNet: Boolean = false,
+): WalletSigner =
+    fromMnemonic(
+        prefix = networkType.prefix,
+        path = networkType.path,
+        mnemonic = mnemonic,
+        passphrase = passphrase,
+        isMainNet = isMainNet
+    )
 
-    constructor(networkType: NetworkType, mnemonic: String, passphrase: String = "") :
-        this(networkType.prefix, networkType.path, mnemonic, passphrase)
+/**
+ * Create a [WalletSigner] from an base58-encoded BIP-32 extended private key.
+ *
+ * @param prefix The human-readable prefix to use when generating network addresses.
+ * @param key The extended private key bytes.
+ * @return [WalletSigner]
+ */
+fun fromBase58EncodedKey(prefix: String, key: String) =
+    WalletSigner(Account.fromBip32(hrp = prefix, bip32 = key))
 
-    val wallet = Wallet.fromMnemonic(prefix, passphrase.toCharArray(), MnemonicWords.of(mnemonic))
+/**
+ * Create a [WalletSigner] from an base58-encoded BIP-32 extended private key.
+ *
+ * @param networkType Use a defined [NetworkType] to specify the path and prefix when generating the signing key.
+ * @param encodedKey The extended private key bytes.
+ * @return [WalletSigner]
+ */
+fun fromBase58EncodedKey(networkType: NetworkType, key: String) =
+    WalletSigner(Account.fromBip32(hrp = networkType.prefix, bip32 = key))
 
-    val account: Account = wallet[path]
+/**
+ * The signing wallet implementation
+ *
+ * @property account The account used for transacting on the blockhain.
+ */
+class WalletSigner(private val account: Account) : Signer {
 
     override fun address(): String = account.address.value
 

--- a/src/test/kotlin/io/provenance/client/PbClientTest.kt
+++ b/src/test/kotlin/io/provenance/client/PbClientTest.kt
@@ -4,7 +4,7 @@ import cosmos.auth.v1beta1.QueryOuterClass
 import cosmos.tx.v1beta1.TxOuterClass
 import io.provenance.client.grpc.BaseReqSigner
 import io.provenance.client.wallet.NetworkType
-import io.provenance.client.wallet.WalletSigner
+import io.provenance.client.wallet.fromMnemonic
 import java.net.URI
 import kotlin.test.assertTrue
 
@@ -15,9 +15,8 @@ class PbClientTest {
         channelUri = URI("http://localhost:9090"),
     )
 
-//    @Test
+    // @Test
     fun testClientQuery() {
-
         pbClient.authClient.accounts(
             QueryOuterClass.QueryAccountsRequest.getDefaultInstance()
         ).also { response ->
@@ -36,7 +35,7 @@ class PbClientTest {
      */
     fun testClientTxn() {
         val mnemonic = "your 20 word phrase here" // todo use your own mnemonic
-        val walletSigner = WalletSigner(NetworkType.TESTNET, mnemonic)
+        val walletSigner = fromMnemonic(NetworkType.TESTNET, mnemonic)
         val txn: TxOuterClass.TxBody = TxOuterClass.TxBody.getDefaultInstance() // todo create your own txn
 
         pbClient.estimateAndBroadcastTx(txn, listOf(BaseReqSigner(walletSigner)))


### PR DESCRIPTION
- Support creating wallets with BIP-32-style encoded extended private keys via the fromBase58EncodedKey() function.