### PR TITLE
undo type change to maintain compatability with pbc 1.7.x based versions

### DIFF
--- a/src/main/kotlin/io/provenance/client/grpc/BaseReq.kt
+++ b/src/main/kotlin/io/provenance/client/grpc/BaseReq.kt
@@ -29,7 +29,7 @@ data class BaseReq(
     val signers: List<BaseReqSigner>,
     val body: TxBody,
     val chainId: String,
-    val gasAdjustment: Float? = null,
+    val gasAdjustment: Double? = null,
     val feeGranter: String? = null
 ) {
 

--- a/src/main/kotlin/io/provenance/client/grpc/GasEstimate.kt
+++ b/src/main/kotlin/io/provenance/client/grpc/GasEstimate.kt
@@ -5,6 +5,6 @@ import cosmos.base.v1beta1.CoinOuterClass
 data class GasEstimate(val limit: Long, val feesCalculated: List<CoinOuterClass.Coin> = emptyList()) {
 
     companion object {
-        const val DEFAULT_FEE_ADJUSTMENT = 1.25f
+        const val DEFAULT_FEE_ADJUSTMENT = 1.25
     }
 }

--- a/src/main/kotlin/io/provenance/client/grpc/PbClient.kt
+++ b/src/main/kotlin/io/provenance/client/grpc/PbClient.kt
@@ -87,7 +87,7 @@ open class PbClient(
     fun baseRequest(
         txBody: TxBody,
         signers: List<BaseReqSigner>,
-        gasAdjustment: Float? = null,
+        gasAdjustment: Double? = null,
         feeGranter: String? = null,
     ): BaseReq =
         signers.map {
@@ -121,7 +121,7 @@ open class PbClient(
                 val msgFee = msgFeeClient.calculateTxFees(
                     CalculateTxFeesRequest.newBuilder()
                         .setTxBytes(txFinal.toByteString())
-                        .setGasAdjustment(baseReq.gasAdjustment ?: GasEstimate.DEFAULT_FEE_ADJUSTMENT)
+                        .setGasAdjustment((baseReq.gasAdjustment ?: GasEstimate.DEFAULT_FEE_ADJUSTMENT).toFloat())
                         .build()
                 )
                 GasEstimate(
@@ -159,7 +159,7 @@ open class PbClient(
         txBody: TxBody,
         signers: List<BaseReqSigner>,
         mode: ServiceOuterClass.BroadcastMode = ServiceOuterClass.BroadcastMode.BROADCAST_MODE_SYNC,
-        gasAdjustment: Float? = null,
+        gasAdjustment: Double? = null,
         feeGranter: String? = null
     ): ServiceOuterClass.BroadcastTxResponse = baseRequest(
         txBody = txBody,
@@ -190,14 +190,14 @@ open class PbClient(
                     .setDenom("nhash")
                     .build()
             ).build()
-        val response = estimateAndBroadcastTx(submitProposal.toAny().toTxBody(), listOf(BaseReqSigner(walletSigner)), gasAdjustment = 1.5f)
+        val response = estimateAndBroadcastTx(submitProposal.toAny().toTxBody(), listOf(BaseReqSigner(walletSigner)), gasAdjustment = 1.5)
         return response
     }
 
     fun voteOnProposal(walletSigner: WalletSigner, proposalId: Long): ServiceOuterClass.BroadcastTxResponse {
         val vote = cosmos.gov.v1beta1.Tx.MsgVote.newBuilder().setProposalId(proposalId).setVoter(walletSigner.address())
             .setOption(Gov.VoteOption.VOTE_OPTION_YES).build()
-        val response = estimateAndBroadcastTx(vote.toAny().toTxBody(), listOf(BaseReqSigner(walletSigner)), gasAdjustment = 1.5f)
+        val response = estimateAndBroadcastTx(vote.toAny().toTxBody(), listOf(BaseReqSigner(walletSigner)), gasAdjustment = 1.5)
         return response
     }
 
@@ -213,7 +213,7 @@ open class PbClient(
                 .setSender(walletSigner.address())
                 .setWasmByteCode(wasmContract)
                 .build().toAny().toTxBody(),
-            listOf(BaseReqSigner(walletSigner)), gasAdjustment = 1.5f, mode = ServiceOuterClass.BroadcastMode.BROADCAST_MODE_BLOCK
+            listOf(BaseReqSigner(walletSigner)), gasAdjustment = 1.5, mode = ServiceOuterClass.BroadcastMode.BROADCAST_MODE_BLOCK
         )
     }
 }

--- a/src/test/kotlin/io/provenance/client/PbClientTest.kt
+++ b/src/test/kotlin/io/provenance/client/PbClientTest.kt
@@ -87,7 +87,7 @@ class PbClientTest {
         val baseRequest = pbClient.baseRequest(
             txBody = txn,
             signers = listOf(BaseReqSigner(wallet)),
-            1.5f
+            1.5
         )
         val estimate: GasEstimate = pbClient.estimateTx(baseRequest)
 
@@ -97,7 +97,7 @@ class PbClientTest {
         val estimatedGwei = estimate.feesCalculated.firstOrNull { it.denom == "gwei" }
         assertNotNull(estimatedGwei, "estimated gwei cannot be null")
 
-        val res = pbClient.estimateAndBroadcastTx(txn, listOf(BaseReqSigner(wallet)), gasAdjustment = 1.5f)
+        val res = pbClient.estimateAndBroadcastTx(txn, listOf(BaseReqSigner(wallet)), gasAdjustment = 1.5)
         assertTrue(
             res.txResponse.code == 0,
             "Did not succeed."
@@ -143,7 +143,7 @@ class PbClientTest {
         val baseRequest = pbClient.baseRequest(
             txBody = listOf(txn, txn2).toTxBody(),
             signers = listOf(BaseReqSigner(wallet)),
-            1.5f
+            1.5
         )
         val estimate: GasEstimate = pbClient.estimateTx(baseRequest)
 
@@ -153,7 +153,7 @@ class PbClientTest {
         val estimatedGwei = estimate.feesCalculated.firstOrNull { it.denom == "gwei" }
         assertNotNull(estimatedGwei, "estimated gwei cannot be null")
 
-        val res = pbClient.estimateAndBroadcastTx(listOf(txn, txn2).toTxBody(), listOf(BaseReqSigner(wallet)), gasAdjustment = 1.5f)
+        val res = pbClient.estimateAndBroadcastTx(listOf(txn, txn2).toTxBody(), listOf(BaseReqSigner(wallet)), gasAdjustment = 1.5)
         assertTrue(
             res.txResponse.code == 0,
             "Did not succeed."


### PR DESCRIPTION
This change rolls back changes made to the api that restrict options when handling code that needs to run on both `1.7.x` and `1.8.y` of pbc - i.e. version pinning.