### PR TITLE
Add fallback pricing for gas estimations

### DIFF
--- a/src/main/kotlin/io/provenance/client/gas/prices/GasPrices.kt
+++ b/src/main/kotlin/io/provenance/client/gas/prices/GasPrices.kt
@@ -10,14 +10,5 @@ fun GasPrices.cached(ttl: Duration = 1.hours): GasPrices = CachedGasPrice(this, 
 
 fun GasPrices.withFallbackPrice(gasPrice: CoinOuterClass.Coin): GasPrices {
     val parent = this
-
-    return object : GasPrices {
-        override fun invoke(): CoinOuterClass.Coin {
-            return try {
-                parent.invoke()
-            } catch (e: Throwable) {
-                gasPrice
-            }
-        }
-    }
+    return { runCatching { parent.invoke() }.getOrDefault(gasPrice) }
 }

--- a/src/main/kotlin/io/provenance/client/gas/prices/GasPrices.kt
+++ b/src/main/kotlin/io/provenance/client/gas/prices/GasPrices.kt
@@ -7,3 +7,17 @@ import kotlin.time.Duration.Companion.hours
 typealias GasPrices = () -> CoinOuterClass.Coin
 
 fun GasPrices.cached(ttl: Duration = 1.hours): GasPrices = CachedGasPrice(this, ttl)
+
+fun GasPrices.withFallbackPrice(gasPrice: CoinOuterClass.Coin): GasPrices {
+    val parent = this
+
+    return object : GasPrices {
+        override fun invoke(): CoinOuterClass.Coin {
+            return try {
+                parent.invoke()
+            } catch (e: Throwable) {
+                gasPrice
+            }
+        }
+    }
+}


### PR DESCRIPTION
In the event that the dynamic gas pricing fails, allow fallback to some predefined amount as a last resort.