### PR TITLE
Proper combining of fee amounts in the baseReq

### DIFF
--- a/src/main/kotlin/io/provenance/client/grpc/BaseReq.kt
+++ b/src/main/kotlin/io/provenance/client/grpc/BaseReq.kt
@@ -3,6 +3,7 @@ package io.provenance.client.grpc
 import com.google.protobuf.Any
 import com.google.protobuf.ByteString
 import cosmos.auth.v1beta1.Auth
+import cosmos.base.v1beta1.CoinOuterClass
 import cosmos.crypto.secp256k1.Keys
 import cosmos.tx.signing.v1beta1.Signing.SignMode
 import cosmos.tx.v1beta1.TxOuterClass.AuthInfo
@@ -12,6 +13,8 @@ import cosmos.tx.v1beta1.TxOuterClass.ModeInfo.Single
 import cosmos.tx.v1beta1.TxOuterClass.SignDoc
 import cosmos.tx.v1beta1.TxOuterClass.SignerInfo
 import cosmos.tx.v1beta1.TxOuterClass.TxBody
+import io.provenance.client.internal.extensions.discreteSum
+import io.provenance.client.internal.extensions.toCoin
 
 interface Signer {
     fun address(): String
@@ -37,7 +40,7 @@ data class BaseReq(
         AuthInfo.newBuilder()
             .setFee(
                 Fee.newBuilder()
-                    .addAllAmount(gasEstimate.feesCalculated)
+                    .addAllAmount(gasEstimate.feesCalculated.discreteSum())
                     .setGasLimit(gasEstimate.limit)
                     .also {
                         if (feeGranter != null) {

--- a/src/main/kotlin/io/provenance/client/grpc/BaseReq.kt
+++ b/src/main/kotlin/io/provenance/client/grpc/BaseReq.kt
@@ -3,7 +3,6 @@ package io.provenance.client.grpc
 import com.google.protobuf.Any
 import com.google.protobuf.ByteString
 import cosmos.auth.v1beta1.Auth
-import cosmos.base.v1beta1.CoinOuterClass
 import cosmos.crypto.secp256k1.Keys
 import cosmos.tx.signing.v1beta1.Signing.SignMode
 import cosmos.tx.v1beta1.TxOuterClass.AuthInfo
@@ -14,7 +13,6 @@ import cosmos.tx.v1beta1.TxOuterClass.SignDoc
 import cosmos.tx.v1beta1.TxOuterClass.SignerInfo
 import cosmos.tx.v1beta1.TxOuterClass.TxBody
 import io.provenance.client.internal.extensions.discreteSum
-import io.provenance.client.internal.extensions.toCoin
 
 interface Signer {
     fun address(): String

--- a/src/main/kotlin/io/provenance/client/grpc/PbClient.kt
+++ b/src/main/kotlin/io/provenance/client/grpc/PbClient.kt
@@ -29,9 +29,13 @@ open class PbClient(
     channelConfigLambda: (NettyChannelBuilder) -> Unit = { }
 ) : Closeable {
 
+    companion object {
+        private val SECURE_URL_SCHEMES = listOf("https", "grpcs")
+    }
+
     val channel = NettyChannelBuilder.forAddress(channelUri.host, channelUri.port)
         .apply {
-            if (channelUri.scheme == "grpcs") {
+            if (channelUri.scheme in SECURE_URL_SCHEMES) {
                 useTransportSecurity()
             } else {
                 usePlaintext()

--- a/src/main/kotlin/io/provenance/client/internal/extensions/CoinExtensions.kt
+++ b/src/main/kotlin/io/provenance/client/internal/extensions/CoinExtensions.kt
@@ -30,3 +30,9 @@ internal operator fun CoinOuterClass.Coin.times(other: BigDecimal): CoinOuterCla
         .setAmount(amount.toBigDecimal().times(other).toPlainString())
         .build()
 }
+
+internal fun List<CoinOuterClass.Coin>.discreteSum(): List<CoinOuterClass.Coin> =
+    groupBy { it.denom }
+        .toSortedMap()
+        .map { it.key to it.value.sumOf { it.amount.toBigInteger() } }
+        .map { "${it.second}${it.first}".toCoin() }

--- a/src/test/kotlin/io/provenance/client/internal/extensions/CoinExtensionsTest.kt
+++ b/src/test/kotlin/io/provenance/client/internal/extensions/CoinExtensionsTest.kt
@@ -52,4 +52,28 @@ class CoinExtensionsTest {
         val newCoin = coin * factor
         Assert.assertNotEquals(3e24.toBigDecimal().toPlainString(), newCoin.amount)
     }
+
+    @Test
+    fun testListCoinDiscreteSum() {
+        val listDiff = listOf("1000foo", "1000bar", "1000baz").map { it.toCoin() }
+        val dsDiff = listDiff.discreteSum()
+        val expectDiff = listOf("1000bar", "1000baz", "1000foo").map { it.toCoin() }
+
+        // Different coins should come out the same.
+        Assert.assertEquals(expectDiff, dsDiff)
+
+        val listSame = listOf("1000foo", "1000foo", "1000foo").map { it.toCoin() }
+        val dsSame = listSame.discreteSum()
+        val expectSame = listOf("3000foo".toCoin())
+
+        // Same coins should sum
+        Assert.assertEquals(expectSame, dsSame)
+
+        val listMixed = listOf("1000foo", "1000bar", "1000foo", "1000bar").map { it.toCoin() }
+        val dsMixed = listMixed.discreteSum()
+        val expectMixed = listOf("2000bar", "2000foo").map { it.toCoin() }
+
+        // Mixed coins should sum and be ordered by denom
+        Assert.assertEquals(expectMixed, dsMixed)
+    }
 }


### PR DESCRIPTION
* Provevance Blockchain expects the fees to be combined by denom and sorted. Make it so.
* Add https to supported tls schemes for urls.