### PR TITLE
v1.3.0-rc1 Release Proposal

### DIFF
--- a/cli/build.gradle.kts
+++ b/cli/build.gradle.kts
@@ -5,6 +5,10 @@ plugins {
 
 repositories {
     mavenCentral()
+    // TODO: Remove staging repository reference when v1.13.0 is officially merged
+    maven {
+        url = uri("https://s01.oss.sonatype.org/content/groups/staging/")
+    }
 }
 
 dependencies {

--- a/client-common/build.gradle.kts
+++ b/client-common/build.gradle.kts
@@ -5,6 +5,10 @@ plugins {
 
 repositories {
     mavenCentral()
+    // TODO: Remove staging repository reference when v1.13.0 is officially merged
+    maven {
+        url = uri("https://s01.oss.sonatype.org/content/groups/staging/")
+    }
 }
 
 dependencies {

--- a/client-coroutines/build.gradle.kts
+++ b/client-coroutines/build.gradle.kts
@@ -4,6 +4,10 @@ plugins {
 
 repositories {
     mavenCentral()
+    // TODO: Remove staging repository reference when v1.13.0 is officially merged
+    maven {
+        url = uri("https://s01.oss.sonatype.org/content/groups/staging/")
+    }
 }
 
 dependencies {

--- a/client/build.gradle.kts
+++ b/client/build.gradle.kts
@@ -5,6 +5,10 @@ plugins {
 
 repositories {
     mavenCentral()
+    // TODO: Remove staging repository reference when v1.13.0 is officially merged
+    maven {
+        url = uri("https://s01.oss.sonatype.org/content/groups/staging/")
+    }
 }
 
 dependencies {

--- a/client/src/main/kotlin/io/provenance/client/grpc/AbstractPbClient.kt
+++ b/client/src/main/kotlin/io/provenance/client/grpc/AbstractPbClient.kt
@@ -52,6 +52,7 @@ open class AbstractPbClient<T : ManagedChannelBuilder<T>>(
     val evidenceClient = cosmos.evidence.v1beta1.QueryGrpc.newBlockingStub(channel)
     val feegrantClient = cosmos.feegrant.v1beta1.QueryGrpc.newBlockingStub(channel)
     val govClient = cosmos.gov.v1beta1.QueryGrpc.newBlockingStub(channel)
+    val groupClient = cosmos.group.v1.QueryGrpc.newBlockingStub(channel)
     val markerClient = io.provenance.marker.v1.QueryGrpc.newBlockingStub(channel)
     val metadataClient = io.provenance.metadata.v1.QueryGrpc.newBlockingStub(channel)
     val mintClient = cosmos.mint.v1beta1.QueryGrpc.newBlockingStub(channel)

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,5 +1,5 @@
 [versions]
-provenance-protos = "1.8.0"
+provenance-protos = "1.13.0-rc3"
 provenance-hd-wallet = "0.1.15"
 bouncycastle = "1.70"
 grpc = "1.44.0"


### PR DESCRIPTION
# Description
This branch will not be merged, but will be used to create a prerelease named v1.3.0-rc1 that contains the new groups module.  After groups are released in Provenance 1.13.0, this branch can be repurposed, after removing the TODOS, to have the groups protos ready to use.

If I receive approvals, I will create said prerelease branch for use in early-access development.  I appreciate your time and attention.