### PR TITLE
add group client with provenance 1.13.0

### DIFF
--- a/client/src/main/kotlin/io/provenance/client/grpc/AbstractPbClient.kt
+++ b/client/src/main/kotlin/io/provenance/client/grpc/AbstractPbClient.kt
@@ -52,6 +52,7 @@ open class AbstractPbClient<T : ManagedChannelBuilder<T>>(
     val evidenceClient = cosmos.evidence.v1beta1.QueryGrpc.newBlockingStub(channel)
     val feegrantClient = cosmos.feegrant.v1beta1.QueryGrpc.newBlockingStub(channel)
     val govClient = cosmos.gov.v1beta1.QueryGrpc.newBlockingStub(channel)
+    val groupClient = cosmos.group.v1.QueryGrpc.newBlockingStub(channel)
     val markerClient = io.provenance.marker.v1.QueryGrpc.newBlockingStub(channel)
     val metadataClient = io.provenance.metadata.v1.QueryGrpc.newBlockingStub(channel)
     val mintClient = cosmos.mint.v1beta1.QueryGrpc.newBlockingStub(channel)

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,5 +1,5 @@
 [versions]
-provenance-protos = "1.8.0"
+provenance-protos = "1.13.0"
 provenance-hd-wallet = "0.1.15"
 bouncycastle = "1.70"
 grpc = "1.44.0"


### PR DESCRIPTION
This is the successor to https://github.com/provenance-io/pb-grpc-client-kotlin/pull/41. Please consider merging and releasing so that we can use the new `group` module.