### PR TITLE
Remove the duplicate channel.shutdown() call in the AbstractPbClient

### DIFF
--- a/client/src/main/kotlin/io/provenance/client/grpc/AbstractPbClient.kt
+++ b/client/src/main/kotlin/io/provenance/client/grpc/AbstractPbClient.kt
@@ -29,10 +29,7 @@ open class AbstractPbClient<T : ManagedChannelBuilder<T>>(
 ) : Closeable {
 
     // Graceful shutdown of the grpc managed channel.
-    private val channelClose: () -> Unit = {
-        channel.shutdown()
-        channel.shutdown().awaitTermination(10, TimeUnit.SECONDS)
-    }
+    private val channelClose: () -> Unit = { channel.shutdown().awaitTermination(10, TimeUnit.SECONDS) }
 
     override fun close() = channelClose()
 


### PR DESCRIPTION
This code currently invokes shutdown on the client twice when it only needs to occur once.