### PR TITLE
Opts isn't used in abstract client, channel config wasn't called in the builder. Use both correctly

### DIFF
--- a/client/src/main/kotlin/io/provenance/client/grpc/AbstractPbClient.kt
+++ b/client/src/main/kotlin/io/provenance/client/grpc/AbstractPbClient.kt
@@ -24,7 +24,6 @@ open class AbstractPbClient<T : ManagedChannelBuilder<T>>(
     open val channelUri: URI,
     open val gasEstimationMethod: GasEstimator,
     open val fromAddress: (String, Int) -> T,
-    opts: ChannelOpts = ChannelOpts(),
     channel: ManagedChannel,
 ) : Closeable {
 

--- a/client/src/main/kotlin/io/provenance/client/grpc/PbClient.kt
+++ b/client/src/main/kotlin/io/provenance/client/grpc/PbClient.kt
@@ -35,5 +35,5 @@ open class PbClient(
     override val gasEstimationMethod: GasEstimator,
     opts: ChannelOpts = ChannelOpts(),
     channelConfigLambda: (NettyChannelBuilder) -> Unit = { },
-    channel: ManagedChannel = grpcChannel(channelUri, opts, NettyChannelBuilder::forAddress),
-) : AbstractPbClient<NettyChannelBuilder>(chainId, channelUri, gasEstimationMethod, NETTY_CHANNEL, opts, channel)
+    channel: ManagedChannel = grpcChannel(channelUri, opts, NettyChannelBuilder::forAddress, channelConfigLambda),
+) : AbstractPbClient<NettyChannelBuilder>(chainId, channelUri, gasEstimationMethod, NETTY_CHANNEL, channel)


### PR DESCRIPTION
Channel config lambda was never used. Make sure it's applied to the channel on creation. Channel opts was never used in the abstract client, remove it since we can use channel config lambda.