### PR TITLE
Feature: Include provenance 1.15.1 protos in build

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -5,7 +5,7 @@ figuretech-hdwallet = "0.4.1"
 grpc = "1.55.1"
 kotlin = "1.7.20"
 kotlinx-core = "1.6.4"
-provenance-protos = "1.15.0"
+provenance-protos = "1.15.1"
 
 [libraries]
 kotlin = { module = "org.jetbrains.kotlin:kotlin-stdlib", version.ref = "kotlin" }


### PR DESCRIPTION
# Description
Keeps the client up to date with the latest protos.