### PR TITLE
Add optional handler arg to allow for tracking tx hash before broadcast

### DIFF
--- a/client/src/main/kotlin/io/provenance/client/grpc/AbstractPbClient.kt
+++ b/client/src/main/kotlin/io/provenance/client/grpc/AbstractPbClient.kt
@@ -118,7 +118,7 @@ open class AbstractPbClient<T : ManagedChannelBuilder<T>>(
         baseReq: BaseReq,
         gasEstimate: GasEstimate,
         mode: ServiceOuterClass.BroadcastMode = ServiceOuterClass.BroadcastMode.BROADCAST_MODE_SYNC,
-        hashHandler: PreBroadcastTxHashHandler? = null,
+        txHashHandler: PreBroadcastTxHashHandler? = null,
     ): ServiceOuterClass.BroadcastTxResponse {
 
         val authInfoBytes = baseReq.buildAuthInfo(gasEstimate).toByteString()
@@ -134,7 +134,7 @@ open class AbstractPbClient<T : ManagedChannelBuilder<T>>(
                 .build()
         }
 
-        hashHandler?.let { it(txRaw.txHash()) }
+        txHashHandler?.let { it(txRaw.txHash()) }
 
         return cosmosService.broadcastTx(
             ServiceOuterClass.BroadcastTxRequest.newBuilder().setTxBytes(txRaw.toByteString()).setMode(mode).build()
@@ -148,14 +148,14 @@ open class AbstractPbClient<T : ManagedChannelBuilder<T>>(
         gasAdjustment: Double? = null,
         feeGranter: String? = null,
         feePayer: String? = null,
-        hashHandler: PreBroadcastTxHashHandler? = null,
+        txHashHandler: PreBroadcastTxHashHandler? = null,
     ): ServiceOuterClass.BroadcastTxResponse = baseRequest(
         txBody = txBody,
         signers = signers,
         gasAdjustment = gasAdjustment,
         feeGranter = feeGranter,
         feePayer = feePayer,
-    ).let { baseReq -> broadcastTx(baseReq, estimateTx(baseReq), mode, hashHandler = hashHandler) }
+    ).let { baseReq -> broadcastTx(baseReq, estimateTx(baseReq), mode, txHashHandler = txHashHandler) }
 }
 
 /**

--- a/client/src/main/kotlin/io/provenance/client/grpc/AbstractPbClient.kt
+++ b/client/src/main/kotlin/io/provenance/client/grpc/AbstractPbClient.kt
@@ -12,6 +12,8 @@ import io.grpc.stub.MetadataUtils
 import io.provenance.client.common.gas.GasEstimate
 import io.provenance.client.protobuf.extensions.getBaseAccount
 import io.provenance.msgfees.v1.QueryParamsRequest
+import tech.figure.hdwallet.common.hashing.sha256
+import tech.figure.hdwallet.encoding.base16.Base16
 import java.io.Closeable
 import java.net.URI
 import java.util.concurrent.TimeUnit
@@ -115,7 +117,8 @@ open class AbstractPbClient<T : ManagedChannelBuilder<T>>(
     fun broadcastTx(
         baseReq: BaseReq,
         gasEstimate: GasEstimate,
-        mode: ServiceOuterClass.BroadcastMode = ServiceOuterClass.BroadcastMode.BROADCAST_MODE_SYNC
+        mode: ServiceOuterClass.BroadcastMode = ServiceOuterClass.BroadcastMode.BROADCAST_MODE_SYNC,
+        hashHandler: PreBroadcastTxHashHandler? = null,
     ): ServiceOuterClass.BroadcastTxResponse {
 
         val authInfoBytes = baseReq.buildAuthInfo(gasEstimate).toByteString()
@@ -131,6 +134,8 @@ open class AbstractPbClient<T : ManagedChannelBuilder<T>>(
                 .build()
         }
 
+        hashHandler?.let { it(txRaw.txHash()) }
+
         return cosmosService.broadcastTx(
             ServiceOuterClass.BroadcastTxRequest.newBuilder().setTxBytes(txRaw.toByteString()).setMode(mode).build()
         )
@@ -143,13 +148,14 @@ open class AbstractPbClient<T : ManagedChannelBuilder<T>>(
         gasAdjustment: Double? = null,
         feeGranter: String? = null,
         feePayer: String? = null,
+        hashHandler: PreBroadcastTxHashHandler? = null,
     ): ServiceOuterClass.BroadcastTxResponse = baseRequest(
         txBody = txBody,
         signers = signers,
         gasAdjustment = gasAdjustment,
         feeGranter = feeGranter,
         feePayer = feePayer,
-    ).let { baseReq -> broadcastTx(baseReq, estimateTx(baseReq), mode) }
+    ).let { baseReq -> broadcastTx(baseReq, estimateTx(baseReq), mode, hashHandler = hashHandler) }
 }
 
 /**
@@ -179,3 +185,7 @@ fun <S : AbstractStub<S>> S.addBlockHeight(blockHeight: String): S {
     metadata.put(io.grpc.Metadata.Key.of(BLOCK_HEIGHT, Metadata.ASCII_STRING_MARSHALLER), blockHeight)
     return withInterceptors(MetadataUtils.newAttachHeadersInterceptor(metadata))
 }
+
+typealias PreBroadcastTxHashHandler = (String) -> Unit
+private fun TxOuterClass.TxRaw.txHash(): String = toByteArray().sha256().toHexString()
+private fun ByteArray.toHexString(): String = Base16.encode(this).uppercase()


### PR DESCRIPTION
Currently the PbClient creates the tx payload internally and as such there is no way to precalculate the tx hash before broadcasting to the chain, instead you have to rely on receiving the response from chain with the hash in the payload. This is less than ideal as sometimes the broadcast might time out but the transaction will still end up on chain, but there is no good way to track the transaction in that case.

This optional handler allows the client to receive the tx hash before broadcast and do whatever they want to do with it for tracking purposes, etc.