### PR TITLE
Faux block mode

### DIFF
--- a/client-common/build.gradle.kts
+++ b/client-common/build.gradle.kts
@@ -12,6 +12,7 @@ dependencies {
         libs.grpc.alts,
         libs.grpc.netty,
         libs.provenance.protos,
+        libs.figuretech.hdwallet,
     ).forEach(::api)
 
     testImplementation(libs.kotlin.test.junit)

--- a/client-common/src/main/kotlin/io/provenance/client/common/exceptions/TransactionTimeoutException.kt
+++ b/client-common/src/main/kotlin/io/provenance/client/common/exceptions/TransactionTimeoutException.kt
@@ -1,4 +1,4 @@
-package io.provenance.client.exceptions
+package io.provenance.client.common.exceptions
 
 import io.grpc.Status
 import io.grpc.StatusRuntimeException

--- a/client-common/src/main/kotlin/io/provenance/client/common/extensions/TxExtensions.kt
+++ b/client-common/src/main/kotlin/io/provenance/client/common/extensions/TxExtensions.kt
@@ -1,0 +1,8 @@
+package io.provenance.client.common.extensions
+
+import cosmos.tx.v1beta1.TxOuterClass
+import tech.figure.hdwallet.common.hashing.sha256
+import tech.figure.hdwallet.encoding.base16.Base16
+
+fun TxOuterClass.TxRaw.txHash(): String = toByteArray().sha256().toHexString()
+fun ByteArray.toHexString(): String = Base16.encode(this).uppercase()

--- a/client-coroutines/build.gradle.kts
+++ b/client-coroutines/build.gradle.kts
@@ -13,6 +13,7 @@ dependencies {
         libs.grpc.netty,
         libs.kotlinx.coroutines,
         libs.provenance.protos,
+        libs.protobuf.kotlin,
     ).forEach(::api)
 
     listOf(

--- a/client-coroutines/src/main/kotlin/io/provenance/client/coroutines/PbCoroutinesClient.kt
+++ b/client-coroutines/src/main/kotlin/io/provenance/client/coroutines/PbCoroutinesClient.kt
@@ -103,11 +103,6 @@ open class PbCoroutinesClient(
             authInfo = baseReq.buildAuthInfo()
             signatures.add(ByteString.EMPTY)
         }
-//        val tx = mkTx {
-//            body = baseReq.body
-//            authInfo = baseReq.buildAuthInfo()
-//            signaturesList.add(ByteString.EMPTY)
-//        }
 
         val gasAdjustment = baseReq.gasAdjustment ?: GasEstimate.DEFAULT_FEE_ADJUSTMENT
         return gasEstimationMethod(this, transaction, gasAdjustment)

--- a/client-coroutines/src/test/kotlin/io/provenance/client/coroutines/PbClientTest.kt
+++ b/client-coroutines/src/test/kotlin/io/provenance/client/coroutines/PbClientTest.kt
@@ -1,12 +1,24 @@
 package io.provenance.client.coroutines
 
 import cosmos.auth.v1beta1.QueryOuterClass
+import cosmos.bank.v1beta1.Tx
+import cosmos.base.v1beta1.coin
+import cosmos.tx.v1beta1.ServiceOuterClass
+import cosmos.tx.v1beta1.TxOuterClass
+import io.provenance.client.grpc.BaseReqSigner
+import io.provenance.client.protobuf.extensions.toAny
+import io.provenance.client.wallet.WalletSigner
+import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.runTest
 import org.junit.Ignore
+import tech.figure.hdwallet.bip39.MnemonicWords
+import tech.figure.hdwallet.hrp.Hrp
+import tech.figure.hdwallet.wallet.Wallet
 import java.net.URI
 import kotlin.test.Test
 import kotlin.test.assertTrue
 
+@OptIn(ExperimentalCoroutinesApi::class)
 @Ignore
 class PbClientTest {
     val pbClient = PbCoroutinesClient(
@@ -27,4 +39,35 @@ class PbClientTest {
             )
         }
     }
+
+    @Test
+    fun `Simulated BROADCAST_MODE_BLOCK works`() = runTest {
+        val signer = testWalletSigner()
+        val result = pbClient.estimateAndBroadcastTx(
+            TxOuterClass.TxBody.newBuilder().addMessages(
+                Tx.MsgSend.newBuilder()
+                .setFromAddress(signer.address())
+                .setToAddress(signer.address())
+                .addAmount(coin {
+                    this.amount = "1"
+                    this.denom = "nhash"
+                }).build()
+                .toAny()).build(),
+            listOf(BaseReqSigner(signer)),
+            mode = ServiceOuterClass.BroadcastMode.BROADCAST_MODE_BLOCK,
+        )
+
+        assert(result.txResponse.height > 0) { "Transaction response had no height" }
+        assert(result.txResponse.code == 0) { "Transaction not successful" }
+    }
+
+    private fun testWalletSigner(): WalletSigner =
+        MnemonicWords.generate().let {
+            Wallet.fromMnemonic(
+                hrp = Hrp.ProvenanceBlockchain.testnet,
+                passphrase = "",
+                mnemonicWords = it,
+                testnet = true
+            )
+        }.let { WalletSigner(it["m/44'/1'/0'/0'/0'"]) }
 }

--- a/client-coroutines/src/test/kotlin/io/provenance/client/coroutines/PbClientTest.kt
+++ b/client-coroutines/src/test/kotlin/io/provenance/client/coroutines/PbClientTest.kt
@@ -5,7 +5,11 @@ import cosmos.bank.v1beta1.Tx
 import cosmos.base.v1beta1.coin
 import cosmos.tx.v1beta1.ServiceOuterClass
 import cosmos.tx.v1beta1.TxOuterClass
+import cosmos.tx.v1beta1.getTxRequest
+import io.grpc.StatusException
+import io.grpc.StatusRuntimeException
 import io.provenance.client.grpc.BaseReqSigner
+import io.provenance.client.protobuf.extensions.getTx
 import io.provenance.client.protobuf.extensions.toAny
 import io.provenance.client.wallet.WalletSigner
 import kotlinx.coroutines.ExperimentalCoroutinesApi
@@ -59,6 +63,44 @@ class PbClientTest {
 
         assert(result.txResponse.height > 0) { "Transaction response had no height" }
         assert(result.txResponse.code == 0) { "Transaction not successful" }
+    }
+
+    @Test
+    fun `Simulated BROADCAST_MODE_SYNC works`() = runTest {
+        val signer = testWalletSigner()
+        var preHash: String? = null
+        val result = pbClient.estimateAndBroadcastTx(
+            TxOuterClass.TxBody.newBuilder().addMessages(
+                Tx.MsgSend.newBuilder()
+                    .setFromAddress(signer.address())
+                    .setToAddress(signer.address())
+                    .addAmount(coin {
+                        this.amount = "1"
+                        this.denom = "nhash"
+                    }).build()
+                    .toAny()).build(),
+            listOf(BaseReqSigner(signer)),
+            mode = ServiceOuterClass.BroadcastMode.BROADCAST_MODE_SYNC,
+            txHashHandler = { preHash = it }
+        )
+
+        assert(preHash != null) { "preHash not received" }
+        assert(result.txResponse.txhash == preHash) { "Transaction response had no txHash" }
+        var tx: ServiceOuterClass.GetTxResponse? = null
+        for (i in 1..6) {
+            try {
+                tx = pbClient.cosmosService.getTx(getTxRequest { hash = preHash!! })
+            } catch (e: StatusException) {
+                if (e.message?.contains("not found") == true) {
+                    Thread.sleep(1000)
+                    continue
+                }
+                throw e
+            }
+        }
+        assert(tx != null) { "Transaction $preHash not fetched" }
+        assert(tx!!.txResponse.height > 0) { "Transaction response had no height" }
+        assert(tx.txResponse.code == 0) { "Transaction not successful" }
     }
 
     private fun testWalletSigner(): WalletSigner =

--- a/client/src/main/kotlin/io/provenance/client/exceptions/TransactionTimeoutException.kt
+++ b/client/src/main/kotlin/io/provenance/client/exceptions/TransactionTimeoutException.kt
@@ -1,0 +1,6 @@
+package io.provenance.client.exceptions
+
+import io.grpc.Status
+import io.grpc.StatusRuntimeException
+
+class TransactionTimeoutException(message: String): StatusRuntimeException(Status.DEADLINE_EXCEEDED.withDescription(message))

--- a/client/src/main/kotlin/io/provenance/client/grpc/AbstractPbClient.kt
+++ b/client/src/main/kotlin/io/provenance/client/grpc/AbstractPbClient.kt
@@ -1,21 +1,33 @@
 package io.provenance.client.grpc
 
+import com.google.common.util.concurrent.Futures
+import com.google.common.util.concurrent.ListenableFuture
+import com.google.common.util.concurrent.MoreExecutors
 import com.google.protobuf.ByteString
-import cosmos.tx.v1beta1.ServiceOuterClass
+import cosmos.base.tendermint.v1beta1.getLatestBlockRequest
+import cosmos.tx.v1beta1.ServiceOuterClass.BroadcastMode
+import cosmos.tx.v1beta1.ServiceOuterClass.BroadcastTxRequest
+import cosmos.tx.v1beta1.ServiceOuterClass.BroadcastTxResponse
 import cosmos.tx.v1beta1.TxOuterClass
+import cosmos.tx.v1beta1.TxOuterClass.TxRaw
 import io.grpc.Channel
 import io.grpc.ManagedChannel
 import io.grpc.ManagedChannelBuilder
 import io.grpc.Metadata
+import io.grpc.StatusRuntimeException
 import io.grpc.stub.AbstractStub
 import io.grpc.stub.MetadataUtils
 import io.provenance.client.common.gas.GasEstimate
+import io.provenance.client.exceptions.TransactionTimeoutException
 import io.provenance.client.protobuf.extensions.getBaseAccount
+import io.provenance.client.protobuf.extensions.getTx
 import io.provenance.msgfees.v1.QueryParamsRequest
 import tech.figure.hdwallet.common.hashing.sha256
 import tech.figure.hdwallet.encoding.base16.Base16
 import java.io.Closeable
 import java.net.URI
+import java.util.concurrent.ExecutorService
+import java.util.concurrent.Executors
 import java.util.concurrent.TimeUnit
 
 open class AbstractPbClient<T : ManagedChannelBuilder<T>>(
@@ -24,10 +36,13 @@ open class AbstractPbClient<T : ManagedChannelBuilder<T>>(
     open val gasEstimationMethod: GasEstimator,
     open val fromAddress: (String, Int) -> T,
     channel: ManagedChannel,
+    txPollingThreadPool: ExecutorService = Executors.newFixedThreadPool(5)
 ) : Closeable {
 
     // Graceful shutdown of the grpc managed channel.
     private val channelClose: () -> Unit = { channel.shutdown().awaitTermination(10, TimeUnit.SECONDS) }
+
+    internal open val txPollingThreadPool = MoreExecutors.listeningDecorator(txPollingThreadPool)
 
     override fun close() = channelClose()
 
@@ -119,10 +134,10 @@ open class AbstractPbClient<T : ManagedChannelBuilder<T>>(
     fun broadcastTx(
         baseReq: BaseReq,
         gasEstimate: GasEstimate,
-        mode: ServiceOuterClass.BroadcastMode = ServiceOuterClass.BroadcastMode.BROADCAST_MODE_SYNC,
+        mode: BroadcastMode = BroadcastMode.BROADCAST_MODE_SYNC,
         txHashHandler: PreBroadcastTxHashHandler? = null,
         signatures: List<ByteArray?> = List(baseReq.signers.size) { null },
-    ): ServiceOuterClass.BroadcastTxResponse {
+    ): ListenableFuture<BroadcastTxResponse> {
         val authInfoBytes = baseReq.buildAuthInfo(gasEstimate).toByteString()
         val txBodyBytes = baseReq.body.toByteString()
 
@@ -147,9 +162,9 @@ open class AbstractPbClient<T : ManagedChannelBuilder<T>>(
 
         txHashHandler?.let { it(txRaw.txHash()) }
 
-        return cosmosService.broadcastTx(
-            ServiceOuterClass.BroadcastTxRequest.newBuilder().setTxBytes(txRaw.toByteString()).setMode(mode).build()
-        )
+        return txRaw.emulateBlockMode(mode, baseReq.body.timeoutHeight) { req ->
+            cosmosService.broadcastTx(req)
+        }
     }
 
     /**
@@ -168,13 +183,13 @@ open class AbstractPbClient<T : ManagedChannelBuilder<T>>(
     fun estimateAndBroadcastTx(
         txBody: TxOuterClass.TxBody,
         signers: List<BaseReqSigner>,
-        mode: ServiceOuterClass.BroadcastMode = ServiceOuterClass.BroadcastMode.BROADCAST_MODE_SYNC,
+        mode: BroadcastMode = BroadcastMode.BROADCAST_MODE_SYNC,
         gasAdjustment: Double? = null,
         feeGranter: String? = null,
         feePayer: String? = null,
         txHashHandler: PreBroadcastTxHashHandler? = null,
         signatures: List<ByteArray?> = List(signers.size) { null },
-    ): ServiceOuterClass.BroadcastTxResponse =
+    ): ListenableFuture<BroadcastTxResponse> =
         baseRequest(
             txBody = txBody,
             signers = signers,
@@ -190,6 +205,47 @@ open class AbstractPbClient<T : ManagedChannelBuilder<T>>(
                 signatures = signatures
             )
         }
+
+    private fun TxRaw.emulateBlockMode(
+        mode: BroadcastMode,
+        providedTimeoutHeight: Long,
+        handler: (BroadcastTxRequest) -> BroadcastTxResponse
+    ): ListenableFuture<BroadcastTxResponse> {
+        val (actualMode, simulateBlock) = if (mode == BroadcastMode.BROADCAST_MODE_BLOCK) {
+            BroadcastMode.BROADCAST_MODE_SYNC to true
+        } else {
+            mode to false
+        }
+        return handler(BroadcastTxRequest.newBuilder()
+            .setTxBytes(this.toByteString())
+            .setMode(actualMode)
+            .build()
+        ).let { res ->
+            if (simulateBlock) {
+                txPollingThreadPool.submit<BroadcastTxResponse> {
+                    val timeoutHeight = providedTimeoutHeight.takeIf { it > 0 } ?: (latestHeight() + 10) // default to 10 block timeout for polling if no height set
+                    val txHash = res.txResponse.txhash
+                    do {
+                        try {
+                            val tx = cosmosService.getTx(txHash)
+                            return@submit res.toBuilder()
+                                .setTxResponse(tx.txResponse)
+                                .build()
+                        } catch (e: StatusRuntimeException) {
+                            if (e.message?.contains("not found") == true) {
+                                Thread.sleep(1000)
+                                continue
+                            }
+                            throw e
+                        }
+                    } while (latestHeight() <= timeoutHeight)
+                    throw TransactionTimeoutException("Failed to complete transaction with hash $txHash by height $timeoutHeight")
+                }
+            } else Futures.immediateFuture(res)
+        }
+    }
+
+    fun latestHeight() = this@AbstractPbClient.tendermintService.getLatestBlock(getLatestBlockRequest {  }).block.header.height
 }
 
 /**

--- a/client/src/main/kotlin/io/provenance/client/grpc/AbstractPbClient.kt
+++ b/client/src/main/kotlin/io/provenance/client/grpc/AbstractPbClient.kt
@@ -18,7 +18,7 @@ import io.grpc.StatusRuntimeException
 import io.grpc.stub.AbstractStub
 import io.grpc.stub.MetadataUtils
 import io.provenance.client.common.gas.GasEstimate
-import io.provenance.client.exceptions.TransactionTimeoutException
+import io.provenance.client.common.exceptions.TransactionTimeoutException
 import io.provenance.client.protobuf.extensions.getBaseAccount
 import io.provenance.client.protobuf.extensions.getTx
 import io.provenance.msgfees.v1.QueryParamsRequest
@@ -153,7 +153,7 @@ open class AbstractPbClient<T : ManagedChannelBuilder<T>>(
         }
             .map { ByteString.copyFrom(it) }
             .let {
-                TxOuterClass.TxRaw.newBuilder()
+                TxRaw.newBuilder()
                     .setAuthInfoBytes(authInfoBytes)
                     .setBodyBytes(txBodyBytes)
                     .addAllSignatures(it)
@@ -278,5 +278,5 @@ fun <S : AbstractStub<S>> S.addBlockHeight(blockHeight: String): S {
 
 typealias PreBroadcastTxHashHandler = (String) -> Unit
 
-private fun TxOuterClass.TxRaw.txHash(): String = toByteArray().sha256().toHexString()
+private fun TxRaw.txHash(): String = toByteArray().sha256().toHexString()
 private fun ByteArray.toHexString(): String = Base16.encode(this).uppercase()

--- a/client/src/test/kotlin/io/provenance/client/PbClientTest.kt
+++ b/client/src/test/kotlin/io/provenance/client/PbClientTest.kt
@@ -4,13 +4,18 @@ import cosmos.auth.v1beta1.Auth
 import cosmos.auth.v1beta1.QueryOuterClass
 import cosmos.bank.v1beta1.Tx.MsgSend
 import cosmos.base.v1beta1.coin
+import cosmos.bank.v1beta1.msgSend
 import cosmos.tx.v1beta1.ServiceOuterClass
+import cosmos.tx.v1beta1.ServiceOuterClass.GetTxResponse
 import cosmos.tx.v1beta1.TxOuterClass
+import io.grpc.StatusRuntimeException
 import io.provenance.client.grpc.BaseReqSigner
 import io.provenance.client.grpc.GasEstimationMethod
 import io.provenance.client.grpc.PbClient
+import io.provenance.client.protobuf.extensions.getTx
 import io.provenance.client.protobuf.extensions.toAny
 import io.provenance.client.wallet.WalletSigner
+import io.provenance.marker.v1.msgTransferRequest
 import tech.figure.hdwallet.bip39.MnemonicWords
 import tech.figure.hdwallet.hrp.Hrp
 import tech.figure.hdwallet.wallet.Wallet
@@ -81,10 +86,48 @@ class PbClientTest {
             .toAny()).build(),
             listOf(BaseReqSigner(signer)),
             mode = ServiceOuterClass.BroadcastMode.BROADCAST_MODE_BLOCK,
-        ).get()
+        )
 
         assert(result.txResponse.height > 0) { "Transaction response had no height" }
         assert(result.txResponse.code == 0) { "Transaction not successful" }
+    }
+
+    @Test
+    @Ignore("requires grpc connection")
+    fun `Simulated BROADCAST_MODE_SYNC works`() {
+        val signer = testWalletSigner()
+        var preHash: String? = null
+        val result = pbClient.estimateAndBroadcastTx(
+            TxOuterClass.TxBody.newBuilder().addMessages(MsgSend.newBuilder()
+                .setFromAddress(signer.address())
+                .setToAddress(signer.address())
+                .addAmount(coin {
+                    this.amount = "1"
+                    this.denom = "nhash"
+                }).build()
+                .toAny()).build(),
+            listOf(BaseReqSigner(signer)),
+            mode = ServiceOuterClass.BroadcastMode.BROADCAST_MODE_SYNC,
+            txHashHandler = { preHash = it }
+        )
+
+        assert(preHash != null) { "preHash not received" }
+        assert(result.txResponse.txhash == preHash) { "Transaction response had no txHash" }
+        var tx: GetTxResponse? = null
+        for (i in 1..6) {
+            try {
+                tx = pbClient.cosmosService.getTx(preHash!!)
+            } catch (e: StatusRuntimeException) {
+                if (e.message?.contains("not found") == true) {
+                    Thread.sleep(1000)
+                    continue
+                }
+                throw e
+            }
+        }
+        assert(tx != null) { "Transaction $preHash not fetched" }
+        assert(tx!!.txResponse.height > 0) { "Transaction response had no height" }
+        assert(tx.txResponse.code == 0) { "Transaction not successful" }
     }
 
     private fun testWalletSigner(): WalletSigner =

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -6,6 +6,7 @@ grpc = "1.55.1"
 kotlin = "1.9.10"
 kotlinx-core = "1.6.4"
 provenance-protos = "1.16.0"
+protobuf = "3.23.2"
 
 [libraries]
 kotlin = { module = "org.jetbrains.kotlin:kotlin-stdlib", version.ref = "kotlin" }
@@ -25,6 +26,7 @@ grpc-alts = { module = "io.grpc:grpc-alts", version.ref = "grpc" }
 grpc-netty = { module = "io.grpc:grpc-netty", version.ref = "grpc" }
 
 provenance-protos = { module = "io.provenance:proto-kotlin", version.ref = "provenance-protos" }
+protobuf-kotlin = { module = "com.google.protobuf:protobuf-kotlin", version.ref = "protobuf" }
 
 kotlinx-coroutines = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-core", version.ref = "kotlinx-core" }
 kotlinx-coroutines-test = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-test", version.ref = "kotlinx-core" }


### PR DESCRIPTION
BROADCAST_MODE_BLOCK is deprecated from cosmos sdk v0.47.x onwards and will fail to work once Provenance is on that version. We have talked for a while about the need to shim in a simulated version of blocking mode to allow for an easy transition away from the actual underlying mode. This is an attempt at doing that.