### PR TITLE
add an empty signature for each signer when performing estimate

### DIFF
--- a/client-coroutines/src/main/kotlin/io/provenance/client/coroutines/PbCoroutinesClient.kt
+++ b/client-coroutines/src/main/kotlin/io/provenance/client/coroutines/PbCoroutinesClient.kt
@@ -12,7 +12,6 @@ import cosmos.tx.v1beta1.TxOuterClass.TxBody
 import cosmos.tx.v1beta1.getTxRequest
 import cosmos.tx.v1beta1.tx
 import io.grpc.StatusException
-import io.grpc.StatusRuntimeException
 import io.grpc.netty.NettyChannelBuilder
 import io.provenance.client.common.exceptions.TransactionTimeoutException
 import io.provenance.client.common.extensions.txHash
@@ -102,7 +101,7 @@ open class PbCoroutinesClient(
         val transaction = tx {
             body = baseReq.body
             authInfo = baseReq.buildAuthInfo()
-            signatures.add(ByteString.EMPTY)
+            signatures.addAll(baseReq.signers.map { ByteString.EMPTY })
         }
 
         val gasAdjustment = baseReq.gasAdjustment ?: GasEstimate.DEFAULT_FEE_ADJUSTMENT

--- a/client/src/main/kotlin/io/provenance/client/grpc/AbstractPbClient.kt
+++ b/client/src/main/kotlin/io/provenance/client/grpc/AbstractPbClient.kt
@@ -14,9 +14,9 @@ import io.grpc.Metadata
 import io.grpc.StatusRuntimeException
 import io.grpc.stub.AbstractStub
 import io.grpc.stub.MetadataUtils
-import io.provenance.client.common.gas.GasEstimate
 import io.provenance.client.common.exceptions.TransactionTimeoutException
 import io.provenance.client.common.extensions.txHash
+import io.provenance.client.common.gas.GasEstimate
 import io.provenance.client.protobuf.extensions.getBaseAccount
 import io.provenance.client.protobuf.extensions.getTx
 import io.provenance.msgfees.v1.QueryParamsRequest
@@ -105,7 +105,8 @@ open class AbstractPbClient<T : ManagedChannelBuilder<T>>(
         val tx = TxOuterClass.Tx.newBuilder()
             .setBody(baseReq.body)
             .setAuthInfo(baseReq.buildAuthInfo())
-            .addSignatures(ByteString.EMPTY) // signatures are not used for estimates, but a value is required
+            // signatures are not used for estimates, but a value is required for each signer
+            .addAllSignatures(baseReq.signers.map { ByteString.EMPTY })
             .build()
         val gasAdjustment = baseReq.gasAdjustment ?: GasEstimate.DEFAULT_FEE_ADJUSTMENT
 


### PR DESCRIPTION
Addresses the error `io.grpc.StatusRuntimeException: UNKNOWN: codespace sdk code 18: invalid request: wrong number of signers; expected 2, got 1: unauthorized` on estimate