### PR TITLE
bypass faux block mode polling on sync checktx failure

### DIFF
--- a/client-coroutines/src/main/kotlin/io/provenance/client/coroutines/PbCoroutinesClient.kt
+++ b/client-coroutines/src/main/kotlin/io/provenance/client/coroutines/PbCoroutinesClient.kt
@@ -172,7 +172,7 @@ open class PbCoroutinesClient(
             .setMode(actualMode)
             .build()
         ).let { res ->
-            if (simulateBlock) {
+            if (simulateBlock && res.txResponse.code == 0) {
                 val timeoutHeight = providedTimeoutHeight.takeIf { it > 0 } ?: (latestHeight() + 10) // default to 10 block timeout for polling if no height set
                 val txHash = res.txResponse.txhash
                 do {

--- a/client/src/main/kotlin/io/provenance/client/grpc/AbstractPbClient.kt
+++ b/client/src/main/kotlin/io/provenance/client/grpc/AbstractPbClient.kt
@@ -213,7 +213,7 @@ open class AbstractPbClient<T : ManagedChannelBuilder<T>>(
             .setMode(actualMode)
             .build()
         ).let { res ->
-            if (simulateBlock) {
+            if (simulateBlock && res.txResponse.code == 0) {
                 val timeoutHeight = providedTimeoutHeight.takeIf { it > 0 } ?: (latestHeight() + 10) // default to 10 block timeout for polling if no height set
                 val txHash = res.txResponse.txhash
                 do {


### PR DESCRIPTION
- otherwise, timeout has to be hit and exception is thrown vs. initial error returned