### PR TITLE
feat: add pre-built ManagedChannel constructor to PbClient for shaded-Netty compatibility

### DIFF
--- a/client/src/main/kotlin/io/provenance/client/grpc/PbClient.kt
+++ b/client/src/main/kotlin/io/provenance/client/grpc/PbClient.kt
@@ -39,7 +39,6 @@ open class PbClient private constructor(
 
     /**
      * Primary constructor: builds a [ManagedChannel] from [NettyChannelBuilder] using the provided options.
-     * Requires `grpc-netty` (unshaded) on the classpath.
      */
     constructor(
         chainId: String,
@@ -58,8 +57,6 @@ open class PbClient private constructor(
 
     /**
      * Secondary constructor: accepts a pre-built [ManagedChannel] directly.
-     * Safe to use on classpaths that only have `grpc-netty-shaded` (no unshaded `grpc-netty`),
-     * because [NETTY_CHANNEL] (which references `io.grpc.netty.NettyChannelBuilder`) is never loaded.
      */
     constructor(
         chainId: String,

--- a/client/src/main/kotlin/io/provenance/client/grpc/PbClient.kt
+++ b/client/src/main/kotlin/io/provenance/client/grpc/PbClient.kt
@@ -29,11 +29,48 @@ fun createChannel(uri: URI, opts: ChannelOpts, config: NettyChannelBuilder.() ->
 /**
  * Netty
  */
-open class PbClient(
+open class PbClient private constructor(
     override val chainId: String,
     override val channelUri: URI,
     override val gasEstimationMethod: GasEstimator,
-    opts: ChannelOpts = ChannelOpts(),
-    channelConfigLambda: (NettyChannelBuilder) -> Unit = { },
-    channel: ManagedChannel = grpcChannel(channelUri, opts, NettyChannelBuilder::forAddress, channelConfigLambda),
-) : AbstractPbClient<NettyChannelBuilder>(chainId, channelUri, gasEstimationMethod, NETTY_CHANNEL, channel)
+    fromAddress: (String, Int) -> NettyChannelBuilder,
+    channel: ManagedChannel,
+) : AbstractPbClient<NettyChannelBuilder>(chainId, channelUri, gasEstimationMethod, fromAddress, channel) {
+
+    /**
+     * Primary constructor: builds a [ManagedChannel] from [NettyChannelBuilder] using the provided options.
+     * Requires `grpc-netty` (unshaded) on the classpath.
+     */
+    constructor(
+        chainId: String,
+        channelUri: URI,
+        gasEstimationMethod: GasEstimator,
+        opts: ChannelOpts = ChannelOpts(),
+        channelConfigLambda: (NettyChannelBuilder) -> Unit = { },
+        channel: ManagedChannel = grpcChannel(channelUri, opts, NettyChannelBuilder::forAddress, channelConfigLambda),
+    ) : this(
+        chainId = chainId,
+        channelUri = channelUri,
+        gasEstimationMethod = gasEstimationMethod,
+        fromAddress = NETTY_CHANNEL,
+        channel = channel,
+    )
+
+    /**
+     * Secondary constructor: accepts a pre-built [ManagedChannel] directly.
+     * Safe to use on classpaths that only have `grpc-netty-shaded` (no unshaded `grpc-netty`),
+     * because [NETTY_CHANNEL] (which references `io.grpc.netty.NettyChannelBuilder`) is never loaded.
+     */
+    constructor(
+        chainId: String,
+        channelUri: URI,
+        gasEstimationMethod: GasEstimator,
+        channel: ManagedChannel,
+    ) : this(
+        chainId = chainId,
+        channelUri = channelUri,
+        gasEstimationMethod = gasEstimationMethod,
+        fromAddress = { _, _ -> error("fromAddress is not available when PbClient is constructed with a pre-built ManagedChannel") },
+        channel = channel,
+    )
+}


### PR DESCRIPTION
## Overview
Applications that exclude unshaded grpc-netty in favor of grpc-netty-shaded cannot instantiate `PbClient` at all, even when they supply their own pre-built ManagedChannel. Further, newer versions of Netty (like those bundled with spring 4) are incompatible `PbClient`'s current usage.

The root cause is in the bytecode of the previous primary constructor; regardless of whether a channel argument was supplied, the primary constructor unconditionally called `ChannelType.from(NettyChannelBuilder::forAddress)`. That call triggers the static initializer — loading the unshaded NettyChannelBuilder class at instantiation time. On a shaded-only classpath, this throws `NoClassDefFoundError: io/grpc/netty/NettyChannelBuilder` before any user code can run.

## Changes
Introduce a private canonical constructor that accepts fromAddress as an explicit parameter and calls `AbstractPbClient` directly. Both public constructors delegate to it:

- The existing public constructor (chainId, channelUri, gasEstimationMethod, opts, channelConfigLambda, channel) passes fromAddress = NETTY_CHANNEL — identical runtime behavior to before, no behavior change for existing consumers.
- A new public constructor (chainId, channelUri, gasEstimationMethod, channel) passes a no-op fromAddress lambda that throws `IllegalStateException` if ever invoked. Because this lambda is a plain `{ _, _ -> error(...) }` expression with no class literal references to `NettyChannelBuilder`, its static initializer does not trigger loading of `io.grpc.netty.NettyChannelBuilder`. The `NETTY_CHANNEL` singleton is never touched.

## Long-term note

This is a minimal, non-breaking fix. The proper long-term solution would be to either (a) split into separate artifacts (`pb-grpc-client-netty-kotlin` / `pb-grpc-client-netty-shaded-kotlin`) so classpath requirements are explicit, or (b) promote `AbstractPbClient` as the primary consumer-facing type and remove the `NettyChannelBuilder` type parameter from the public API surface. This PR intentionally defers that decision.